### PR TITLE
Fix the XY letter system for non-square grids

### DIFF
--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -213,7 +213,7 @@ export class Game {
             text = String.fromCharCode(index + 65)
           } else if (this.letterSystem == "letters-xy" || this.letterSystem == "hybrid") {
             const x = index % this.cols
-            const y = Math.floor(index / this.rows)
+            const y = Math.floor(index / this.cols)
             text = String.fromCharCode(x + (x < 26 ? 65 : 71))
               + (this.letterSystem == "hybrid"
                   ? (y + 1).toString()


### PR DESCRIPTION
Hey, just a small fix to turn this:
![image](https://github.com/user-attachments/assets/dd290e69-6f37-4378-8580-cfef66432a9b)
into this:
![image](https://github.com/user-attachments/assets/5d829daf-008d-4695-97f6-79a0b484f879)
